### PR TITLE
Despatched / DespatchedDate Issue

### DIFF
--- a/lib/asendia/shipment.rb
+++ b/lib/asendia/shipment.rb
@@ -15,6 +15,18 @@ module Asendia
     attribute :tracking_number, String
     attribute :tracking_url,    String
 
+    def dispatched?
+      if dispatched && dispatched_on.nil?
+        STDERR.puts "DESPATCHED set without DESPATCHEDDATE (shipment ID: #{id})"
+      end
+
+      if dispatched_on && !dispatched
+        STDERR.puts "DESPATCHEDDATE set without DESPATCHED (shipment ID: #{id})"
+      end
+
+      dispatched && !!dispatched_on
+    end
+
     def self.fetch(client, order_ids)
       response = client.request(
         :get_order,

--- a/lib/asendia/version.rb
+++ b/lib/asendia/version.rb
@@ -1,5 +1,5 @@
 module Asendia
   # First two integers represent the Asendia API version number, and as a
   # result should not change unless Asendia update their API.
-  VERSION = '1.5.2'.freeze
+  VERSION = '1.5.3'.freeze
 end


### PR DESCRIPTION
This PR fixes an issue we've spotted with the Asendia API where `despatched` isn't set but `despatcheddate` is. We're now requiring both fields to be set and have added logging if one is set without the other.