### PR TITLE
Fix issue with date parsing

### DIFF
--- a/lib/asendia/shipment.rb
+++ b/lib/asendia/shipment.rb
@@ -38,14 +38,11 @@ module Asendia
     end
 
     def self.new_from_api(record)
-      dispatch_date = record[:despatcheddate]
-      dispatch_date = Date.parse(dispatch_date) unless dispatch_date.nil?
-
       Shipment.new(
         id:              record[:orderid],
         delivery_method: record[:deliverymethod],
         dispatched:      record[:despatched] == 'Yes',
-        dispatched_on:   dispatch_date,
+        dispatched_on:   record[:despatcheddate],
         picking_status:  record[:pickingstatus].downcase,
         tracking_number: record[:trackno],
         tracking_url:    parse_tracking_link(record[:tracknolink])

--- a/lib/asendia/shipment.rb
+++ b/lib/asendia/shipment.rb
@@ -42,7 +42,10 @@ module Asendia
         id:              record[:orderid],
         delivery_method: record[:deliverymethod],
         dispatched:      record[:despatched] == 'Yes',
+
+        # DespatchedDate is set to nil by Savon if not present:
         dispatched_on:   record[:despatcheddate],
+
         picking_status:  record[:pickingstatus].downcase,
         tracking_number: record[:trackno],
         tracking_url:    parse_tracking_link(record[:tracknolink])

--- a/lib/asendia/version.rb
+++ b/lib/asendia/version.rb
@@ -1,5 +1,5 @@
 module Asendia
   # First two integers represent the Asendia API version number, and as a
   # result should not change unless Asendia update their API.
-  VERSION = '1.5.3'.freeze
+  VERSION = '1.5.4'.freeze
 end


### PR DESCRIPTION
Savon parses dates automatically so the `Date.parse` call was causing errors.